### PR TITLE
[WIP] Non-git mixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.venv*
 
 # Spyder project settings
 .spyderproject

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,13 +258,14 @@ repository they can be run with the following:
 
 ```bash
 $ HUGGINGFACE_CO_STAGING=1 python -m pytest -sv ./tests
+```
 
-In fact, that's how `make test` is implemented (sans the `pip install` line)!
+In fact, that's how `make test` is implemented (without the `pip install` line)!
 
 You can specify a smaller set of tests in order to test only the feature
 you're working on.
 
-For example, the following will only run the tests hel in the `test_repository.py` file:
+For example, the following will only run the tests in the `test_repository.py` file:
 
 ```bash
 $ HUGGINGFACE_CO_STAGING=1 python -m pytest -sv ./tests/test_repository.py

--- a/docs/source/how-to-manage.mdx
+++ b/docs/source/how-to-manage.mdx
@@ -1,6 +1,6 @@
 # Create and manage a repository
 
-A repository is a space for you to store your model or dataset files. This guide will show you how to:
+A repository is a place where you can store your model or dataset files. This guide will show you how to:
 
 * Create and delete a repository.
 * Adjust repository visibility.

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ extras["fastai"] = [
 
 extras["tensorflow"] = ["tensorflow", "pydot", "graphviz"]
 
+extras["ml"] = extras["torch"] + extras["fastai"] + extras["tensorflow"]
+
 extras["testing"] = [
     "pytest",
     "pytest-cov",

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1427,7 +1427,7 @@ class HfApi:
         )
         return [f.rfilename for f in repo_info.siblings]
 
-    @_deprecate_positional_args
+    @_deprecate_positional_args(version="0.8")
     def create_repo(
         self,
         repo_id: str = None,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -63,6 +63,7 @@ else:
 REGEX_DISCUSSION_URL = re.compile(r".*/discussions/(\d+)$")
 USERNAME_PLACEHOLDER = "hf_user"
 
+logger = logging.get_logger(__name__)
 
 # TODO: remove after deprecation period is over (v0.10)
 def _validate_repo_id_deprecation(repo_id, name, organization):
@@ -96,9 +97,6 @@ def _validate_repo_id_deprecation(repo_id, name, organization):
         else:
             organization, name = None, repo_id
     return name, organization
-
-
-logger = logging.get_logger(__name__)
 
 
 def repo_type_and_id_from_hf_id(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -19,7 +19,6 @@ import sys
 import warnings
 from os.path import expanduser
 from typing import BinaryIO, Dict, Iterable, List, Optional, Tuple, Union
-from urllib.parse import quote
 
 import requests
 from requests.exceptions import HTTPError

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -65,6 +65,7 @@ USERNAME_PLACEHOLDER = "hf_user"
 
 logger = logging.get_logger(__name__)
 
+
 # TODO: remove after deprecation period is over (v0.10)
 def _validate_repo_id_deprecation(repo_id, name, organization):
     """Returns (name, organization) from the input."""

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1428,7 +1428,7 @@ class HfApi:
         )
         return [f.rfilename for f in repo_info.siblings]
 
-    @_deprecate_positional_args(version="0.8")
+    @_deprecate_positional_args(version="0.12")
     def create_repo(
         self,
         repo_id: str = None,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -63,8 +63,6 @@ else:
 REGEX_DISCUSSION_URL = re.compile(r".*/discussions/(\d+)$")
 USERNAME_PLACEHOLDER = "hf_user"
 
-logger = logging.get_logger(__name__)
-
 
 # TODO: remove after deprecation period is over (v0.10)
 def _validate_repo_id_deprecation(repo_id, name, organization):

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -9,9 +9,10 @@ from huggingface_hub import hf_api
 
 from .constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 from .file_download import hf_hub_download, is_torch_available
-from .hf_api import HfApi
+from .hf_api import HfApi, HfFolder
+from .repository import Repository
 from .utils import logging
-from .utils._deprecation import _deprecate_positional_args
+from .utils._deprecation import _deprecate_arguments, _deprecate_positional_args
 
 
 if is_torch_available():
@@ -214,26 +215,48 @@ class ModelHubMixin:
         pretrained"""
         raise NotImplementedError
 
-    @_deprecate_positional_args(version="0.11")
+    @_deprecate_positional_args(version="0.12")
+    @_deprecate_arguments(
+        version="0.12",
+        deprecated_args={
+            "repo_url",
+            "repo_path_or_name",
+            "organization",
+            "use_auth_token",
+            "git_user",
+            "git_email",
+            "skip_lfs_files",
+        },
+    )
     def push_to_hub(
         self,
-        repo_id: str,
-        # TODO: deprecate next arguments (0.11 ?)
+        # NOTE: deprecated signature that will be removed in 0.12
         repo_path_or_name: Optional[str] = None,
         repo_url: Optional[str] = None,
+        commit_message: Optional[str] = "Add model",
+        organization: Optional[str] = None,
+        private: Optional[bool] = None,
+        api_endpoint: Optional[str] = None,
         use_auth_token: Optional[Union[bool, str]] = None,
         git_user: Optional[str] = None,
         git_email: Optional[str] = None,
+        config: Optional[dict] = None,
         skip_lfs_files: bool = False,
-        #
-        *,
-        commit_message: Optional[str] = "Add model",
-        private: Optional[bool] = None,
-        api_endpoint: Optional[str] = None,
+        # NOTE: New arguments since 0.9
+        repo_id: Optional[str] = None,  # optional only until 0.12
         token: Optional[str] = None,
         branch: Optional[str] = None,
         create_pr: Optional[bool] = None,
-        config: Optional[dict] = None,
+        # TODO (release 0.12): signature must be the following
+        # repo_id: str,
+        # *,
+        # commit_message: Optional[str] = "Add model",
+        # private: Optional[bool] = None,
+        # api_endpoint: Optional[str] = None,
+        # token: Optional[str] = None,
+        # branch: Optional[str] = None,
+        # create_pr: Optional[bool] = None,
+        # config: Optional[dict] = None,
     ) -> str:
         """
         Upload model checkpoint to the Hub.
@@ -266,32 +289,89 @@ class ModelHubMixin:
         Returns:
             The url of the commit of your model in the given repository.
         """
-        token = token or use_auth_token  # TODO: remove in 0.11 ?
+        # Repo id is set means we use the new version using HTTP endpoint
+        # (introduced v0.9)
+        if repo_id is not None:
+            token, _ = hf_api._validate_or_retrieve_token(token)
+            api = HfApi(endpoint=api_endpoint)
 
-        token, _ = hf_api._validate_or_retrieve_token(token)
-        api = HfApi(endpoint=api_endpoint)
-
-        api.create_repo(
-            repo_id=repo_id,
-            repo_type="model",
-            token=token,
-            private=private,
-            exist_ok=True,
-        )
-
-        # Push the files to the repo in a single commit
-        with tempfile.TemporaryDirectory() as tmp:
-            saved_path = Path(tmp) / repo_id
-            self.save_pretrained(saved_path, config=config)
-            return api.upload_folder(
+            api.create_repo(
                 repo_id=repo_id,
                 repo_type="model",
                 token=token,
-                folder_path=saved_path,
-                commit_message=commit_message,
-                revision=branch,
-                create_pr=create_pr,
+                private=private,
+                exist_ok=True,
             )
+
+            # Push the files to the repo in a single commit
+            with tempfile.TemporaryDirectory() as tmp:
+                saved_path = Path(tmp) / repo_id
+                self.save_pretrained(saved_path, config=config)
+                return api.upload_folder(
+                    repo_id=repo_id,
+                    repo_type="model",
+                    path_in_repo="",
+                    token=token,
+                    folder_path=saved_path,
+                    commit_message=commit_message,
+                    revision=branch,
+                    create_pr=create_pr,
+                )
+
+        # Repo id is None means we use the deprecated version using Git
+        # TODO: remove code between here and `return repo.git_push()` in release 0.12
+        if repo_path_or_name is None and repo_url is None:
+            raise ValueError(
+                "You need to specify a `repo_path_or_name` or a `repo_url`."
+            )
+
+        if use_auth_token is None and repo_url is None:
+            token = HfFolder.get_token()
+            if token is None:
+                raise ValueError(
+                    "You must login to the Hugging Face hub on this computer by typing"
+                    " `huggingface-cli login` and entering your credentials to use"
+                    " `use_auth_token=True`. Alternatively, you can pass your own token"
+                    " as the `use_auth_token` argument."
+                )
+        elif isinstance(use_auth_token, str):
+            token = use_auth_token
+        else:
+            token = None
+
+        if repo_path_or_name is None:
+            repo_path_or_name = repo_url.split("/")[-1]
+
+        # If no URL is passed and there's no path to a directory containing files, create a repo
+        if repo_url is None and not os.path.exists(repo_path_or_name):
+            repo_id = Path(repo_path_or_name).name
+            if organization:
+                repo_id = f"{organization}/{repo_id}"
+            repo_url = HfApi(endpoint=api_endpoint).create_repo(
+                repo_id=repo_id,
+                token=token,
+                private=private,
+                repo_type=None,
+                exist_ok=True,
+            )
+
+        repo = Repository(
+            repo_path_or_name,
+            clone_from=repo_url,
+            use_auth_token=use_auth_token,
+            git_user=git_user,
+            git_email=git_email,
+            skip_lfs_files=skip_lfs_files,
+        )
+        repo.git_pull(rebase=True)
+
+        # Save the files in the cloned repo
+        self.save_pretrained(repo_path_or_name, config=config)
+
+        # Commit and push!
+        repo.git_add(auto_lfs_track=True)
+        repo.git_commit(commit_message)
+        return repo.git_push()
 
 
 class PyTorchModelHubMixin(ModelHubMixin):

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -34,29 +34,34 @@ class ModelHubMixin:
         self,
         save_directory: str,
         config: Optional[dict] = None,
+        # NOTE: without new arguments this behavior (with push_to_hub=True), will be
+        # deprecated as well. Should we already plan to extend the "save_pretrained"
+        # function or should we let this feature die and then force users to do
+        # `model.save_pretrained(...)` and `model.push_to_hub(...)` separately ?
+        # Main argument that is missing I think is "repo_id". All other are optional but
+        # nice to have.
+        # TODO: To be discussed and to remove before merging PR
         push_to_hub: bool = False,
         **kwargs,
     ):
         """
         Save weights in local directory.
 
-                Parameters:
-                    save_directory (`str`):
-                        Specify directory in which you want to save weights.
-                    config (`dict`, *optional*):
-                        specify config (must be dict) in case you want to save
-                        it.
-                    push_to_hub (`bool`, *optional*, defaults to `False`):
-                        Set it to `True` in case you want to push your weights
-                        to huggingface_hub
-                    kwargs (`Dict`, *optional*):
-                        kwargs will be passed to `push_to_hub`
+        Parameters:
+            save_directory (`str`):
+                Specify directory in which you want to save weights.
+            config (`dict`, *optional*):
+                specify config (must be dict) in case you want to save
+                it.
+            push_to_hub (`bool`, *optional*, defaults to `False`):
+                Set it to `True` in case you want to push your weights to huggingface_hub.
+            kwargs (`Dict`, *optional*):
+                kwargs will be passed to `push_to_hub`
         """
-
         os.makedirs(save_directory, exist_ok=True)
 
         # saving model weights/files
-        files = self._save_pretrained(save_directory)
+        self._save_pretrained(save_directory)
 
         # saving config
         if isinstance(config, dict):
@@ -64,14 +69,10 @@ class ModelHubMixin:
             with open(path, "w") as f:
                 json.dump(config, f)
 
-            files.append(path)
-
         if push_to_hub:
             return self.push_to_hub(save_directory, **kwargs)
 
-        return files
-
-    def _save_pretrained(self, save_directory: str) -> List[str]:
+    def _save_pretrained(self, save_directory: str):
         """
         Overwrite this method in subclass to define how to save your model.
         """
@@ -230,7 +231,7 @@ class ModelHubMixin:
     )
     def push_to_hub(
         self,
-        # NOTE: deprecated signature that will be removed in 0.12
+        # NOTE: deprecated signature that will change in 0.12
         repo_path_or_name: Optional[str] = None,
         repo_url: Optional[str] = None,
         commit_message: Optional[str] = "Add model",

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -74,7 +74,7 @@ class ModelHubMixin:
             if (
                 # If a deprecated argument is passed, we have to use the deprecated
                 # version of `push_to_hub`.
-                # TODO: remove this possibility in v0.11
+                # TODO: remove this possibility in v0.12
                 kwargs.get("repo_url") is not None
                 or kwargs.get("repo_path_or_name") is not None
                 or kwargs.get("organization") is not None

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -312,8 +312,6 @@ class ModelHubMixin:
                 Defaults to `False`.
             config (`dict`, *optional*):
                 Configuration object to be saved alongside the model weights.
-            skip_lfs_files (`bool`, *optional*, defaults to `False`):
-                Whether to skip git-LFS files or not.
 
         Returns:
             The url of the commit of your model in the given repository.

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -34,13 +34,6 @@ class ModelHubMixin:
         self,
         save_directory: str,
         config: Optional[dict] = None,
-        # NOTE: without new arguments this behavior (with push_to_hub=True), will be
-        # deprecated as well. Should we already plan to extend the "save_pretrained"
-        # function or should we let this feature die and then force users to do
-        # `model.save_pretrained(...)` and `model.push_to_hub(...)` separately ?
-        # Main argument that is missing I think is "repo_id". All other are optional but
-        # nice to have.
-        # TODO: To be discussed and to remove before merging PR
         push_to_hub: bool = False,
         **kwargs,
     ):

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -224,6 +224,7 @@ class ModelHubMixin:
         use_auth_token: Optional[Union[bool, str]] = None,
         git_user: Optional[str] = None,
         git_email: Optional[str] = None,
+        skip_lfs_files: bool = False,
         #
         *,
         commit_message: Optional[str] = "Add model",
@@ -233,7 +234,6 @@ class ModelHubMixin:
         branch: Optional[str] = None,
         create_pr: Optional[bool] = None,
         config: Optional[dict] = None,
-        skip_lfs_files: bool = False,
     ) -> str:
         """
         Upload model checkpoint to the Hub.

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -2,7 +2,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import requests
 from huggingface_hub import hf_api
@@ -214,10 +214,17 @@ class ModelHubMixin:
         pretrained"""
         raise NotImplementedError
 
-    @_deprecate_positional_args(version=0.8)
+    @_deprecate_positional_args(version="0.11")
     def push_to_hub(
         self,
         repo_id: str,
+        # TODO: deprecate next arguments (0.11 ?)
+        repo_path_or_name: Optional[str] = None,
+        repo_url: Optional[str] = None,
+        use_auth_token: Optional[Union[bool, str]] = None,
+        git_user: Optional[str] = None,
+        git_email: Optional[str] = None,
+        #
         *,
         commit_message: Optional[str] = "Add model",
         private: Optional[bool] = None,
@@ -259,6 +266,8 @@ class ModelHubMixin:
         Returns:
             The url of the commit of your model in the given repository.
         """
+        token = token or use_auth_token  # TODO: remove in 0.11 ?
+
         token, _ = hf_api._validate_or_retrieve_token(token)
         api = HfApi(endpoint=api_endpoint)
 

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -282,7 +282,7 @@ def from_pretrained_keras(*args, **kwargs):
     return KerasModelHubMixin.from_pretrained(*args, **kwargs)
 
 
-@_deprecate_positional_args(version=0.8)
+@_deprecate_positional_args(version="0.8")
 def push_to_hub_keras(
     model,
     repo_id: str,

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -411,6 +411,9 @@ def push_to_hub_keras(
             )
 
             if log_dir is not None:
+                # TODO: delete log folder on the hub when it exists
+                # previous implementation using git was doing it in the same git commit
+                # ... to be continued
                 tmp_log_dir = saved_path / "logs"
                 if os.path.exists(tmp_log_dir):
                     rmtree(tmp_log_dir)

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -360,6 +360,7 @@ def push_to_hub_keras(
         exist_ok=True,
     )
 
+    # Push the files to the repo in a single commit
     with tempfile.TemporaryDirectory() as tmp:
         saved_path = Path(tmp) / repo_id
         save_pretrained_keras(
@@ -373,9 +374,10 @@ def push_to_hub_keras(
         )
 
         if log_dir is not None:
-            if os.path.exists(f"{saved_path}/logs"):
-                rmtree(f"{saved_path}/logs")
-            copytree(log_dir, f"{saved_path}/logs")
+            tmp_log_dir = saved_path / "logs"
+            if os.path.exists(tmp_log_dir):
+                rmtree(tmp_log_dir)
+            copytree(log_dir, tmp_log_dir)
 
         return api.upload_folder(
             repo_id=repo_id,

--- a/src/huggingface_hub/utils/_deprecation.py
+++ b/src/huggingface_hub/utils/_deprecation.py
@@ -10,7 +10,7 @@ def _deprecate_positional_args(*, version: str):
     * will issue a warning when passed as a positional argument.
 
     Args:
-        version (``str``):
+        version (`str`):
             The version when positional arguments will result in error.
     """
 
@@ -51,10 +51,12 @@ def _deprecate_positional_args(*, version: str):
 def _deprecate_arguments(*, version: str, deprecated_args: Set[str]):
     """Decorator to issue warnings when using deprecated arguments.
 
+    TODO: could be useful to be able to set a custom error message.
+
     Args:
-        version (``str``):
+        version (`str`):
             The version when deprecated arguments will result in error.
-        deprecated_args (``List[str]``):
+        deprecated_args (`List[str]`):
             List of the arguments to be deprecated.
     """
 

--- a/src/huggingface_hub/utils/_deprecation.py
+++ b/src/huggingface_hub/utils/_deprecation.py
@@ -1,52 +1,86 @@
 import warnings
 from functools import wraps
 from inspect import Parameter, signature
+from typing import Callable, Set
 
 
-def _deprecate_positional_args(func=None, *, version="0.8"):
+def _deprecate_positional_args(func: Callable, *, version: str) -> Callable:
     """Decorator for methods that issues warnings for positional arguments.
     Using the keyword-only argument syntax in pep 3102, arguments after the
     * will issue a warning when passed as a positional argument.
 
     Args:
-        func (``Callable``, `optional`):
+        func (``Callable``):
             Function to check arguments on.
-        version (``Callable``, `optional`, defaults to ``"0.8"``):
+        version (``str``):
             The version when positional arguments will result in error.
     """
+    sig = signature(func)
+    kwonly_args = []
+    all_args = []
+    for name, param in sig.parameters.items():
+        if param.kind == Parameter.POSITIONAL_OR_KEYWORD:
+            all_args.append(name)
+        elif param.kind == Parameter.KEYWORD_ONLY:
+            kwonly_args.append(name)
 
-    def _inner_deprecate_positional_args(f):
-        sig = signature(f)
-        kwonly_args = []
-        all_args = []
-        for name, param in sig.parameters.items():
-            if param.kind == Parameter.POSITIONAL_OR_KEYWORD:
-                all_args.append(name)
-            elif param.kind == Parameter.KEYWORD_ONLY:
-                kwonly_args.append(name)
+    @wraps(func)
+    def inner_f(*args, **kwargs):
+        extra_args = len(args) - len(all_args)
+        if extra_args <= 0:
+            return func(*args, **kwargs)
+        # extra_args > 0
+        args_msg = [
+            f"{name}='{arg}'" if isinstance(arg, str) else f"{name}={arg}"
+            for name, arg in zip(kwonly_args[:extra_args], args[-extra_args:])
+        ]
+        args_msg = ", ".join(args_msg)
+        warnings.warn(
+            f"Pass {args_msg} as keyword args. From version {version} passing these as "
+            "positional arguments will result in an error,",
+            FutureWarning,
+        )
+        kwargs.update(zip(sig.parameters, args))
+        return func(**kwargs)
 
-        @wraps(f)
-        def inner_f(*args, **kwargs):
-            extra_args = len(args) - len(all_args)
-            if extra_args <= 0:
-                return f(*args, **kwargs)
-            # extra_args > 0
-            args_msg = [
-                f"{name}='{arg}'" if isinstance(arg, str) else f"{name}={arg}"
-                for name, arg in zip(kwonly_args[:extra_args], args[-extra_args:])
-            ]
-            args_msg = ", ".join(args_msg)
+    return inner_f
+
+
+def _deprecate_arguments(
+    func: Callable, *, version: str, deprecated_args: Set[str]
+) -> Callable:
+    """Decorator to issue warnings when using deprecated arguments.
+
+    Args:
+        func (``Callable``):
+            Function to check arguments on.
+        version (``str``):
+            The version when deprecated arguments will result in error.
+        deprecated_args (``List[str]``):
+            List of the arguments to be deprecated.
+    """
+    sig = signature(func)
+
+    @wraps(func)
+    def inner_f(*args, **kwargs):
+        used_deprecated_args = []
+
+        for _, parameter in zip(args, sig.parameters.values()):
+            if parameter.name in deprecated_args:
+                used_deprecated_args.append(parameter.name)
+
+        for kwarg_name in kwargs:
+            if kwarg_name in deprecated_args:
+                used_deprecated_args.append(kwarg_name)
+
+        if len(used_deprecated_args) > 0:
             warnings.warn(
-                f"Pass {args_msg} as keyword args. From version "
-                f"{version} passing these as positional arguments "
-                "will result in an error",
+                f"Deprecated argument(s) used in '{func.__name__}':"
+                f" {', '.join(used_deprecated_args)}. Will not be supported from"
+                f" version '{version}'.",
                 FutureWarning,
             )
-            kwargs.update(zip(sig.parameters, args))
-            return f(**kwargs)
 
-        return inner_f
+        return func(*args, **kwargs)
 
-    if func is not None:
-        return _inner_deprecate_positional_args(func)
-    return _inner_deprecate_positional_args
+    return inner_f

--- a/src/huggingface_hub/utils/_deprecation.py
+++ b/src/huggingface_hub/utils/_deprecation.py
@@ -52,8 +52,6 @@ def _deprecate_arguments(*, version: str, deprecated_args: Set[str]):
     """Decorator to issue warnings when using deprecated arguments.
 
     Args:
-        func (``Callable``):
-            Function to check arguments on.
         version (``str``):
             The version when deprecated arguments will result in error.
         deprecated_args (``List[str]``):

--- a/src/huggingface_hub/utils/_deprecation.py
+++ b/src/huggingface_hub/utils/_deprecation.py
@@ -1,54 +1,54 @@
 import warnings
 from functools import wraps
 from inspect import Parameter, signature
-from typing import Callable, Set
+from typing import Callable, Optional, Set
 
 
-def _deprecate_positional_args(func: Callable, *, version: str) -> Callable:
+def _deprecate_positional_args(*, version: str):
     """Decorator for methods that issues warnings for positional arguments.
     Using the keyword-only argument syntax in pep 3102, arguments after the
     * will issue a warning when passed as a positional argument.
 
     Args:
-        func (``Callable``):
-            Function to check arguments on.
         version (``str``):
             The version when positional arguments will result in error.
     """
-    sig = signature(func)
-    kwonly_args = []
-    all_args = []
-    for name, param in sig.parameters.items():
-        if param.kind == Parameter.POSITIONAL_OR_KEYWORD:
-            all_args.append(name)
-        elif param.kind == Parameter.KEYWORD_ONLY:
-            kwonly_args.append(name)
 
-    @wraps(func)
-    def inner_f(*args, **kwargs):
-        extra_args = len(args) - len(all_args)
-        if extra_args <= 0:
-            return func(*args, **kwargs)
-        # extra_args > 0
-        args_msg = [
-            f"{name}='{arg}'" if isinstance(arg, str) else f"{name}={arg}"
-            for name, arg in zip(kwonly_args[:extra_args], args[-extra_args:])
-        ]
-        args_msg = ", ".join(args_msg)
-        warnings.warn(
-            f"Pass {args_msg} as keyword args. From version {version} passing these as "
-            "positional arguments will result in an error,",
-            FutureWarning,
-        )
-        kwargs.update(zip(sig.parameters, args))
-        return func(**kwargs)
+    def _inner_deprecate_positional_args(f):
+        sig = signature(f)
+        kwonly_args = []
+        all_args = []
+        for name, param in sig.parameters.items():
+            if param.kind == Parameter.POSITIONAL_OR_KEYWORD:
+                all_args.append(name)
+            elif param.kind == Parameter.KEYWORD_ONLY:
+                kwonly_args.append(name)
 
-    return inner_f
+        @wraps(f)
+        def inner_f(*args, **kwargs):
+            extra_args = len(args) - len(all_args)
+            if extra_args <= 0:
+                return f(*args, **kwargs)
+            # extra_args > 0
+            args_msg = [
+                f"{name}='{arg}'" if isinstance(arg, str) else f"{name}={arg}"
+                for name, arg in zip(kwonly_args[:extra_args], args[-extra_args:])
+            ]
+            args_msg = ", ".join(args_msg)
+            warnings.warn(
+                f"Pass {args_msg} as keyword args. From version {version} passing these"
+                " as positional arguments will result in an error,",
+                FutureWarning,
+            )
+            kwargs.update(zip(sig.parameters, args))
+            return f(**kwargs)
+
+        return inner_f
+
+    return _inner_deprecate_positional_args
 
 
-def _deprecate_arguments(
-    func: Callable, *, version: str, deprecated_args: Set[str]
-) -> Callable:
+def _deprecate_arguments(*, version: str, deprecated_args: Set[str]):
     """Decorator to issue warnings when using deprecated arguments.
 
     Args:
@@ -59,28 +59,31 @@ def _deprecate_arguments(
         deprecated_args (``List[str]``):
             List of the arguments to be deprecated.
     """
-    sig = signature(func)
 
-    @wraps(func)
-    def inner_f(*args, **kwargs):
-        used_deprecated_args = []
+    def _inner_deprecate_positional_args(f):
+        sig = signature(f)
 
-        for _, parameter in zip(args, sig.parameters.values()):
-            if parameter.name in deprecated_args:
-                used_deprecated_args.append(parameter.name)
+        @wraps(f)
+        def inner_f(*args, **kwargs):
+            # Check for used deprecated arguments
+            used_deprecated_args = []
+            for _, parameter in zip(args, sig.parameters.values()):
+                if parameter.name in deprecated_args:
+                    used_deprecated_args.append(parameter.name)
+            for kwarg_name in kwargs:
+                if kwarg_name in deprecated_args:
+                    used_deprecated_args.append(kwarg_name)
 
-        for kwarg_name in kwargs:
-            if kwarg_name in deprecated_args:
-                used_deprecated_args.append(kwarg_name)
+            # Warn and proceed
+            if len(used_deprecated_args) > 0:
+                warnings.warn(
+                    f"Deprecated argument(s) used in '{f.__name__}':"
+                    f" {', '.join(used_deprecated_args)}. Will not be supported from"
+                    f" version '{version}'.",
+                    FutureWarning,
+                )
+            return f(*args, **kwargs)
 
-        if len(used_deprecated_args) > 0:
-            warnings.warn(
-                f"Deprecated argument(s) used in '{func.__name__}':"
-                f" {', '.join(used_deprecated_args)}. Will not be supported from"
-                f" version '{version}'.",
-                FutureWarning,
-            )
+        return inner_f
 
-        return func(*args, **kwargs)
-
-    return inner_f
+    return _inner_deprecate_positional_args

--- a/src/huggingface_hub/utils/_deprecation.py
+++ b/src/huggingface_hub/utils/_deprecation.py
@@ -1,7 +1,7 @@
 import warnings
 from functools import wraps
 from inspect import Parameter, signature
-from typing import Callable, Optional, Set
+from typing import Set
 
 
 def _deprecate_positional_args(*, version: str):

--- a/src/huggingface_hub/utils/endpoint_helpers.py
+++ b/src/huggingface_hub/utils/endpoint_helpers.py
@@ -16,52 +16,7 @@ with the aim for a user-friendly interface.
 import math
 import re
 from dataclasses import dataclass
-from typing import List, Literal, Optional, Union
-from urllib.parse import quote
-
-from huggingface_hub.constants import DEFAULT_REVISION, REPO_TYPES_URL_PREFIXES
-
-
-REGEX_DISCUSSION_URL = re.compile(r".*/discussions/(\d+)$")
-
-
-def _generate_url(
-    content_type: Literal["as_file", "as_folder"],
-    endpoint: str,
-    repo_id: str,
-    path_in_repo: str,
-    repo_type: Optional[str] = None,
-    revision: Optional[str] = None,
-    pr_url: Optional[str] = None,
-):
-    """Safely generate full url to visualize an uploaded file or folder.
-
-    TODO: also use same utility for the `resolve` subpath ?
-          See `HUGGINGFACE_CO_URL_TEMPLATE` from `constants.py`.
-    """
-    if content_type == "as_file":
-        subpath = "blob"
-    elif content_type == "as_folder":
-        subpath = "tree"
-    else:
-        raise ValueError(
-            "Content type must be either 'as_file' or 'as_folder', not"
-            f" '{content_type}',"
-        )
-
-    if pr_url is not None:
-        re_match = re.match(REGEX_DISCUSSION_URL, pr_url)
-        if re_match is None:
-            raise RuntimeError(
-                "Unexpected response from the hub, expected a Pull Request URL but"
-                f" got: '{pr_url}'"
-            )
-        revision = quote(f"refs/pr/{re_match[1]}", safe="")
-
-    if repo_type in REPO_TYPES_URL_PREFIXES:
-        repo_id = REPO_TYPES_URL_PREFIXES[repo_type] + repo_id
-    revision = revision if revision is not None else DEFAULT_REVISION
-    return f"{endpoint}/{repo_id}/{subpath}/{revision}/{path_in_repo}"
+from typing import List, Union
 
 
 def _filter_emissions(

--- a/src/huggingface_hub/utils/endpoint_helpers.py
+++ b/src/huggingface_hub/utils/endpoint_helpers.py
@@ -13,7 +13,6 @@
 Helpful utility functions and classes in relation to exploring API endpoints
 with the aim for a user-friendly interface.
 """
-import enum
 import math
 import re
 from dataclasses import dataclass
@@ -22,13 +21,14 @@ from urllib.parse import quote
 
 from huggingface_hub.constants import DEFAULT_REVISION, REPO_TYPES_URL_PREFIXES
 
+
 REGEX_DISCUSSION_URL = re.compile(r".*/discussions/(\d+)$")
 
 
 def _generate_url(
     content_type: Literal["as_file", "as_folder"],
     endpoint: str,
-    repo_id:str,
+    repo_id: str,
     path_in_repo: str,
     repo_type: Optional[str] = None,
     revision: Optional[str] = None,

--- a/src/huggingface_hub/utils/endpoint_helpers.py
+++ b/src/huggingface_hub/utils/endpoint_helpers.py
@@ -11,13 +11,57 @@
 # limitations under the License.
 """
 Helpful utility functions and classes in relation to exploring API endpoints
-with the aim for a user-friendly interface
+with the aim for a user-friendly interface.
 """
-
+import enum
 import math
 import re
 from dataclasses import dataclass
-from typing import List, Union
+from typing import List, Literal, Optional, Union
+from urllib.parse import quote
+
+from huggingface_hub.constants import DEFAULT_REVISION, REPO_TYPES_URL_PREFIXES
+
+REGEX_DISCUSSION_URL = re.compile(r".*/discussions/(\d+)$")
+
+
+def _generate_url(
+    content_type: Literal["as_file", "as_folder"],
+    endpoint: str,
+    repo_id:str,
+    path_in_repo: str,
+    repo_type: Optional[str] = None,
+    revision: Optional[str] = None,
+    pr_url: Optional[str] = None,
+):
+    """Safely generate full url to visualize an uploaded file or folder.
+
+    TODO: also use same utility for the `resolve` subpath ?
+          See `HUGGINGFACE_CO_URL_TEMPLATE` from `constants.py`.
+    """
+    if content_type == "as_file":
+        subpath = "blob"
+    elif content_type == "as_folder":
+        subpath = "tree"
+    else:
+        raise ValueError(
+            "Content type must be either 'as_file' or 'as_folder', not"
+            f" '{content_type}',"
+        )
+
+    if pr_url is not None:
+        re_match = re.match(REGEX_DISCUSSION_URL, pr_url)
+        if re_match is None:
+            raise RuntimeError(
+                "Unexpected response from the hub, expected a Pull Request URL but"
+                f" got: '{pr_url}'"
+            )
+        revision = quote(f"refs/pr/{re_match[1]}", safe="")
+
+    if repo_type in REPO_TYPES_URL_PREFIXES:
+        repo_id = REPO_TYPES_URL_PREFIXES[repo_type] + repo_id
+    revision = revision if revision is not None else DEFAULT_REVISION
+    return f"{endpoint}/{repo_id}/{subpath}/{revision}/{path_in_repo}"
 
 
 def _filter_emissions(

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -124,7 +124,23 @@ class HubMixingTest(HubMixingCommonTest):
         model = DummyModel.from_pretrained(f"{WORKING_REPO_DIR}/{REPO_NAME}")
         self.assertDictEqual(model.config, {"num": 10, "act": "gelu_fast"})
 
-    def test_push_to_hub(self):
+    def test_push_to_hub_via_http(self):
+        REPO_NAME = repo_name("PUSH_TO_HUB")
+        repo_id = f"{USER}/{REPO_NAME}"
+
+        DummyModel().push_to_hub(
+            repo_id=repo_id,
+            api_endpoint=ENDPOINT_STAGING,
+            use_auth_token=self._token,
+            config={"num": 7, "act": "gelu_fast"},
+        )
+
+        model_info = self._api.model_info(repo_id, token=self._token)
+        self.assertEqual(model_info.modelId, repo_id)
+
+        self._api.delete_repo(repo_id=repo_id, token=self._token)
+
+    def test_push_to_hub_via_git_deprecated(self):
         REPO_NAME = repo_name("PUSH_TO_HUB")
         model = DummyModel()
         model.push_to_hub(

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -127,7 +127,7 @@ class HubMixingTest(HubMixingCommonTest):
         self.assertDictEqual(model.config, {"num": 10, "act": "gelu_fast"})
 
     def test_push_to_hub_via_http_basic(self):
-        REPO_NAME = repo_name("PUSH_TO_HUB")
+        REPO_NAME = repo_name("PUSH_TO_HUB_via_http")
         repo_id = f"{USER}/{REPO_NAME}"
 
         DummyModel().push_to_hub(
@@ -154,7 +154,7 @@ class HubMixingTest(HubMixingCommonTest):
 
     def test_push_to_hub_via_git_deprecated(self):
         # TODO: remove in 0.12 when git method will be removed
-        REPO_NAME = repo_name("PUSH_TO_HUB")
+        REPO_NAME = repo_name("PUSH_TO_HUB_via_git")
         repo_id = f"{USER}/{REPO_NAME}"
 
         with pytest.warns(FutureWarning, match=PUSH_TO_HUB_WARNING_REGEX):
@@ -170,7 +170,7 @@ class HubMixingTest(HubMixingCommonTest):
 
     def test_push_to_hub_via_git_use_lfs_by_default(self):
         # TODO: remove in 0.12 when git method will be removed
-        REPO_NAME = repo_name("PUSH_TO_HUB_LFS")
+        REPO_NAME = repo_name("PUSH_TO_HUB_with_lfs_file")
         with tempfile.TemporaryDirectory() as tmpdirname:
             os.makedirs(f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}")
             self._repo_url = self._api.create_repo(repo_id=REPO_NAME, token=self._token)

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -165,7 +165,7 @@ class HubMixingTest(HubMixingCommonTest):
                 config={"num": 7, "act": "gelu_fast"},
             )
 
-    def test_push_to_hub_depreacted_arguments(self):
+    def test_push_to_hub_deprecated_arguments(self):
         REPO_NAME = repo_name("PUSH_TO_HUB")
         model = DummyModel()
         with pytest.warns(

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -205,7 +205,7 @@ class HubMixingTest(HubMixingCommonTest):
         # TODO: remove in 0.12 when git method will be removed
         REPO_A = repo_name("PUSH_TO_HUB_git_with_existing_files")
         REPO_B = repo_name("PUSH_TO_HUB_git_without_existing_files")
-        self._api.create_repo(token=self._token, name=REPO_A)
+        self._api.create_repo(token=self._token, repo_id=REPO_A)
         for i in range(5):
             self._api.upload_file(
                 # Each are .5mb in size

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -496,8 +496,6 @@ class HubKerasSequentialTest(HubMixingTestKeras):
             )
 
             model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(repo_id)
-            # TODO: this test fails. Both tensorboard.txt and override.txt are in the
-            #       repo at the end.
             self.assertTrue(
                 "logs/override.txt" in [f.rfilename for f in model_info.siblings]
             )

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -334,6 +334,8 @@ class HubKerasSequentialTest(HubMixingTestKeras):
         with self.assertRaises(
             ValueError, msg="Exception encountered when calling layer*"
         ):
+            # TODO: investigate why it doesn't throw an error
+            #       IMHO previous test never worked as intended
             from_pretrained_keras(f"{WORKING_REPO_DIR}/{REPO_NAME}")
 
     def test_from_pretrained_weights(self):
@@ -494,6 +496,8 @@ class HubKerasSequentialTest(HubMixingTestKeras):
             )
 
             model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(repo_id)
+            # TODO: this test fails. Both tensorboard.txt and override.txt are in the
+            #       repo at the end.
             self.assertTrue(
                 "logs/override.txt" in [f.rfilename for f in model_info.siblings]
             )
@@ -531,6 +535,8 @@ class HubKerasSequentialTest(HubMixingTestKeras):
             with self.assertRaises(
                 ValueError, msg="Exception encountered when calling layer*"
             ):
+                # TODO: investigate why it doesn't throw an error
+                #       IMHO previous test never worked as intended
                 from_pretrained_keras(tmpdirname)
 
         self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shutil
 import tempfile
 import time
@@ -8,7 +9,7 @@ import uuid
 
 import pytest
 
-from huggingface_hub import HfApi
+from huggingface_hub import HfApi, hf_hub_download
 from huggingface_hub.file_download import (
     is_graphviz_available,
     is_pydot_available,
@@ -20,6 +21,7 @@ from huggingface_hub.keras_mixin import (
     push_to_hub_keras,
     save_pretrained_keras,
 )
+from huggingface_hub.repository import Repository
 from huggingface_hub.utils import logging
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
@@ -35,6 +37,11 @@ logger = logging.get_logger(__name__)
 WORKING_REPO_SUBDIR = f"fixtures/working_repo_{__name__.split('.')[-1]}"
 WORKING_REPO_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), WORKING_REPO_SUBDIR
+)
+
+PUSH_TO_HUB_WARNING_REGEX = re.escape("Deprecated argument(s) used in 'push_to_hub':")
+PUSH_TO_HUB_KERAS_WARNING_REGEX = re.escape(
+    "Deprecated argument(s) used in 'push_to_hub_keras':"
 )
 
 if is_tf_available():
@@ -152,25 +159,55 @@ class HubMixingTestKeras(unittest.TestCase):
         self.assertDictEqual(model.config, {"num": 10, "act": "gelu_fast"})
 
     @retry_endpoint
-    def test_push_to_hub(self):
-        REPO_NAME = repo_name("PUSH_TO_HUB")
+    def test_push_to_hub_keras_mixin_via_http_basic(self):
+        REPO_NAME = repo_name("PUSH_TO_HUB_KERAS_via_http")
+        repo_id = f"{USER}/{REPO_NAME}"
+
         model = DummyModel()
         model(model.dummy_inputs)
+
         model.push_to_hub(
-            repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
+            repo_id=repo_id,
             api_endpoint=ENDPOINT_STAGING,
-            use_auth_token=self._token,
-            git_user="ci",
-            git_email="ci@dummy.com",
+            token=self._token,
             config={"num": 7, "act": "gelu_fast"},
         )
 
-        model_info = self._api.model_info(
-            f"{USER}/{REPO_NAME}",
-        )
-        self.assertEqual(model_info.modelId, f"{USER}/{REPO_NAME}")
+        # Test model id exists
+        model_info = self._api.model_info(repo_id, token=self._token)
+        self.assertEqual(model_info.modelId, repo_id)
 
-        self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)
+        # Test config has been pushed to hub
+        tmp_config_path = hf_hub_download(
+            repo_id=repo_id, filename="config.json", use_auth_token=self._token
+        )
+        with open(tmp_config_path) as f:
+            self.assertEqual(json.load(f), {"num": 7, "act": "gelu_fast"})
+
+        # Delete tmp file and repo
+        os.remove(tmp_config_path)
+        self._api.delete_repo(repo_id=repo_id, token=self._token)
+
+    @retry_endpoint
+    def test_push_to_hub_keras_mixin_via_git_deprecated(self):
+        REPO_NAME = repo_name("PUSH_TO_HUB_KERAS_via_git")
+        repo_id = f"{USER}/{REPO_NAME}"
+        model = DummyModel()
+        model(model.dummy_inputs)
+
+        with pytest.warns(FutureWarning, match=PUSH_TO_HUB_WARNING_REGEX):
+            model.push_to_hub(
+                repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
+                api_endpoint=ENDPOINT_STAGING,
+                use_auth_token=self._token,
+                git_user="ci",
+                git_email="ci@dummy.com",
+                config={"num": 7, "act": "gelu_fast"},
+            )
+
+        model_info = self._api.model_info(repo_id)
+        self.assertEqual(model_info.modelId, repo_id)
+        self._api.delete_repo(repo_id=repo_id, token=self._token)
 
 
 @require_tf
@@ -294,8 +331,10 @@ class HubKerasSequentialTest(HubMixingTestKeras):
             save_traces=False,
         )
 
-        from_pretrained_keras(f"{WORKING_REPO_DIR}/{REPO_NAME}")
-        self.assertRaises(ValueError, msg="Exception encountered when calling layer*")
+        with self.assertRaises(
+            ValueError, msg="Exception encountered when calling layer*"
+        ):
+            from_pretrained_keras(f"{WORKING_REPO_DIR}/{REPO_NAME}")
 
     def test_from_pretrained_weights(self):
         REPO_NAME = repo_name("FROM_PRETRAINED")
@@ -367,71 +406,68 @@ class HubKerasSequentialTest(HubMixingTestKeras):
         self.assertTrue(new_model.config == {"num": 10, "act": "gelu_fast"})
 
     @retry_endpoint
-    def test_push_to_hub(self):
+    def test_push_to_hub_keras_sequential_via_http_basic(self):
         REPO_NAME = repo_name("PUSH_TO_HUB")
+        repo_id = f"{USER}/{REPO_NAME}"
         model = self.model_init()
-        model.build((None, 2))
+        model = self.model_fit(model)
+
         push_to_hub_keras(
-            model,
-            repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
-            api_endpoint=ENDPOINT_STAGING,
-            use_auth_token=self._token,
-            git_user="ci",
-            git_email="ci@dummy.com",
-            config={"num": 7, "act": "gelu_fast"},
-            include_optimizer=False,
+            model, repo_id=repo_id, token=self._token, api_endpoint=ENDPOINT_STAGING
         )
-
-        model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(
-            f"{USER}/{REPO_NAME}",
-        )
-        self.assertEqual(model_info.modelId, f"{USER}/{REPO_NAME}")
-
-        self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)
+        model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(repo_id)
+        self.assertEqual(model_info.modelId, repo_id)
+        self.assertTrue("README.md" in [f.rfilename for f in model_info.siblings])
+        self.assertTrue("model.png" in [f.rfilename for f in model_info.siblings])
+        self._api.delete_repo(repo_id=repo_id, token=self._token)
 
     @retry_endpoint
-    def test_push_to_hub_model_card_build(self):
+    def test_push_to_hub_keras_sequential_via_http_plot_false(self):
         REPO_NAME = repo_name("PUSH_TO_HUB")
+        repo_id = f"{USER}/{REPO_NAME}"
         model = self.model_init()
-        model.build((None, 2))
+        model = self.model_fit(model)
+
         push_to_hub_keras(
             model,
-            repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
+            repo_id=repo_id,
+            token=self._token,
             api_endpoint=ENDPOINT_STAGING,
-            use_auth_token=self._token,
-            git_user="ci",
-            git_email="ci@dummy.com",
+            plot_model=False,
         )
-        model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(
-            f"{USER}/{REPO_NAME}",
-        )
+        model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(repo_id)
+        self.assertFalse("model.png" in [f.rfilename for f in model_info.siblings])
+        self._api.delete_repo(repo_id=repo_id, token=self._token)
+
+    @retry_endpoint
+    def test_push_to_hub_keras_sequential_via_git_deprecated(self):
+        REPO_NAME = repo_name("PUSH_TO_HUB_KERAS_sequential_via_git")
+        model = self.model_init()
+        model.build((None, 2))
+
+        with pytest.warns(FutureWarning, match=PUSH_TO_HUB_KERAS_WARNING_REGEX):
+            push_to_hub_keras(
+                model,
+                repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
+                api_endpoint=ENDPOINT_STAGING,
+                use_auth_token=self._token,
+                git_user="ci",
+                git_email="ci@dummy.com",
+                config={"num": 7, "act": "gelu_fast"},
+                include_optimizer=False,
+            )
+
+        model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(f"{USER}/{REPO_NAME}")
+        self.assertEqual(model_info.modelId, f"{USER}/{REPO_NAME}")
         self.assertTrue("README.md" in [f.rfilename for f in model_info.siblings])
         self.assertTrue("model.png" in [f.rfilename for f in model_info.siblings])
         self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)
 
     @retry_endpoint
-    def test_push_to_hub_model_card_plot_false(self):
-        REPO_NAME = repo_name("PUSH_TO_HUB")
-        model = self.model_init()
-        model = self.model_fit(model)
-        push_to_hub_keras(
-            model,
-            repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
-            api_endpoint=ENDPOINT_STAGING,
-            use_auth_token=self._token,
-            git_user="ci",
-            git_email="ci@dummy.com",
-            plot_model=False,
-        )
-        model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(
-            f"{USER}/{REPO_NAME}",
-        )
-        self.assertFalse("model.png" in [f.rfilename for f in model_info.siblings])
-        self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)
-
-    @retry_endpoint
-    def test_override_tensorboard(self):
-        REPO_NAME = repo_name("PUSH_TO_HUB")
+    def test_push_to_hub_keras_via_http_override_tensorboard(self):
+        """Test log directory is overwritten when pushing a keras model a 2nd time."""
+        REPO_NAME = repo_name("PUSH_TO_HUB_KERAS_via_http_override_tensorboard")
+        repo_id = f"{USER}/{REPO_NAME}"
         with tempfile.TemporaryDirectory() as tmpdirname:
             os.makedirs(f"{tmpdirname}/tb_log_dir")
             with open(f"{tmpdirname}/tb_log_dir/tensorboard.txt", "w") as fp:
@@ -440,29 +476,24 @@ class HubKerasSequentialTest(HubMixingTestKeras):
             model.build((None, 2))
             push_to_hub_keras(
                 model,
-                repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
+                repo_id=repo_id,
                 log_dir=f"{tmpdirname}/tb_log_dir",
                 api_endpoint=ENDPOINT_STAGING,
-                use_auth_token=self._token,
-                git_user="ci",
-                git_email="ci@dummy.com",
+                token=self._token,
             )
+
             os.makedirs(f"{tmpdirname}/tb_log_dir2")
             with open(f"{tmpdirname}/tb_log_dir2/override.txt", "w") as fp:
                 fp.write("Keras FTW")
             push_to_hub_keras(
                 model,
-                repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
+                repo_id=repo_id,
                 log_dir=f"{tmpdirname}/tb_log_dir2",
                 api_endpoint=ENDPOINT_STAGING,
-                use_auth_token=self._token,
-                git_user="ci",
-                git_email="ci@dummy.com",
+                token=self._token,
             )
 
-            model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(
-                f"{USER}/{REPO_NAME}",
-            )
+            model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(repo_id)
             self.assertTrue(
                 "logs/override.txt" in [f.rfilename for f in model_info.siblings]
             )
@@ -470,32 +501,37 @@ class HubKerasSequentialTest(HubMixingTestKeras):
                 "logs/tensorboard.txt" in [f.rfilename for f in model_info.siblings]
             )
 
-            self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)
+            self._api.delete_repo(repo_id=repo_id, token=self._token)
 
     @retry_endpoint
-    def test_push_to_hub_model_kwargs(self):
-        REPO_NAME = repo_name("PUSH_TO_HUB")
+    def test_push_to_hub_keras_via_http_with_model_kwargs(self):
+        REPO_NAME = repo_name("PUSH_TO_HUB_KERAS_via_http_with_model_kwargs")
+        repo_id = f"{USER}/{REPO_NAME}"
+
         model = self.model_init()
         model = self.model_fit(model)
         push_to_hub_keras(
             model,
-            repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
+            repo_id=repo_id,
             api_endpoint=ENDPOINT_STAGING,
-            use_auth_token=self._token,
-            git_user="ci",
-            git_email="ci@dummy.com",
-            config={"num": 7, "act": "gelu_fast"},
+            token=self._token,
             include_optimizer=True,
             save_traces=False,
         )
 
-        model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(
-            f"{USER}/{REPO_NAME}",
-        )
-        self.assertEqual(model_info.modelId, f"{USER}/{REPO_NAME}")
+        model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(repo_id)
+        self.assertEqual(model_info.modelId, repo_id)
 
-        from_pretrained_keras(f"{WORKING_REPO_DIR}/{REPO_NAME}")
-        self.assertRaises(ValueError, msg="Exception encountered when calling layer*")
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            Repository(
+                local_dir=tmpdirname,
+                clone_from=ENDPOINT_STAGING + "/" + repo_id,
+                use_auth_token=self._token,
+            )
+            with self.assertRaises(
+                ValueError, msg="Exception encountered when calling layer*"
+            ):
+                from_pretrained_keras(tmpdirname)
 
         self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)
 

--- a/tests/test_utils_deprecation.py
+++ b/tests/test_utils_deprecation.py
@@ -10,20 +10,13 @@ from huggingface_hub.utils._deprecation import (
 )
 
 
-def dummy(a, b="b", c="c"):
-    pass
-
-
-def dummy_kwonly(a, *, b="b", c="c"):
-    pass
-
-
 class TestDeprecationUtils(unittest.TestCase):
     def test_deprecate_positional_args(self):
         """Test warnings are triggered when using deprecated positional args."""
-        dummy_position_deprecated = _deprecate_positional_args(
-            dummy_kwonly, version="xxx"
-        )
+
+        @_deprecate_positional_args(version="xxx")
+        def dummy_position_deprecated(a, *, b="b", c="c"):
+            pass
 
         with warnings.catch_warnings():
             # Assert no warnings when used correctly.
@@ -40,12 +33,14 @@ class TestDeprecationUtils(unittest.TestCase):
 
     def test_deprecate_arguments(self):
         """Test warnings are triggered when using deprecated arguments."""
-        dummy_c_deprecated = _deprecate_arguments(
-            dummy, version="xxx", deprecated_args={"c"}
-        )
-        dummy_b_c_deprecated = _deprecate_arguments(
-            dummy, version="xxx", deprecated_args={"b", "c"}
-        )
+
+        @_deprecate_arguments(version="xxx", deprecated_args={"c"})
+        def dummy_c_deprecated(a, b="b", c="c"):
+            pass
+
+        @_deprecate_arguments(version="xxx", deprecated_args={"b", "c"})
+        def dummy_b_c_deprecated(a, b="b", c="c"):
+            pass
 
         with warnings.catch_warnings():
             # Assert no warnings when used correctly.

--- a/tests/test_utils_deprecation.py
+++ b/tests/test_utils_deprecation.py
@@ -10,20 +10,17 @@ from huggingface_hub.utils._deprecation import (
 )
 
 
-def dummy(a, b="b", c="c") -> str:
-    return f"{a}{b}{c}"
+def dummy(a, b="b", c="c"):
+    pass
 
 
-def dummy_kwonly(a, *, b="b", c="c") -> str:
-    return dummy(a, b, c)
+def dummy_kwonly(a, *, b="b", c="c"):
+    pass
 
 
 class TestDeprecationUtils(unittest.TestCase):
     def test_deprecate_positional_args(self):
-        """Test warnings are triggered when using deprecated positional args.
-
-        Also test that the values are well passed to the decorated function.
-        """
+        """Test warnings are triggered when using deprecated positional args."""
         dummy_position_deprecated = _deprecate_positional_args(
             dummy_kwonly, version="xxx"
         )
@@ -32,20 +29,17 @@ class TestDeprecationUtils(unittest.TestCase):
             # Assert no warnings when used correctly.
             # Taken from https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests
             warnings.simplefilter("error")
-            self.assertEqual(dummy_position_deprecated(a="A", b="B", c="C"), "ABC")
-            self.assertEqual(dummy_position_deprecated("A", b="B", c="C"), "ABC")
+            dummy_position_deprecated(a="A", b="B", c="C")
+            dummy_position_deprecated("A", b="B", c="C")
 
         with pytest.warns(FutureWarning):
-            self.assertEqual(dummy_position_deprecated("A", "B", c="C"), "ABC")
+            dummy_position_deprecated("A", "B", c="C")
 
         with pytest.warns(FutureWarning):
-            self.assertEqual(dummy_position_deprecated("A", "B", "C"), "ABC")
+            dummy_position_deprecated("A", "B", "C")
 
     def test_deprecate_arguments(self):
-        """Test warnings are triggered when using deprecated arguments.
-
-        Also test that the values are well passed to the decorated function.
-        """
+        """Test warnings are triggered when using deprecated arguments."""
         dummy_c_deprecated = _deprecate_arguments(
             dummy, version="xxx", deprecated_args={"c"}
         )
@@ -57,26 +51,26 @@ class TestDeprecationUtils(unittest.TestCase):
             # Assert no warnings when used correctly.
             # Taken from https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests
             warnings.simplefilter("error")
-            self.assertEqual(dummy_c_deprecated("A"), "Abc")
-            self.assertEqual(dummy_c_deprecated("A", "B"), "ABc")
-            self.assertEqual(dummy_c_deprecated("A", b="B"), "ABc")
+            dummy_c_deprecated("A")
+            dummy_c_deprecated("A", "B")
+            dummy_c_deprecated("A", b="B")
 
-            self.assertEqual(dummy_b_c_deprecated("A"), "Abc")
-
-        with pytest.warns(FutureWarning):
-            self.assertEqual(dummy_c_deprecated("A", "B", "C"), "ABC")
+            dummy_b_c_deprecated("A")
 
         with pytest.warns(FutureWarning):
-            self.assertEqual(dummy_c_deprecated("A", c="C"), "AbC")
+            dummy_c_deprecated("A", "B", "C")
 
         with pytest.warns(FutureWarning):
-            self.assertEqual(dummy_c_deprecated("A", b="B", c="C"), "ABC")
+            dummy_c_deprecated("A", c="C")
 
         with pytest.warns(FutureWarning):
-            self.assertEqual(dummy_b_c_deprecated("A", b="B"), "ABc")
+            dummy_c_deprecated("A", b="B", c="C")
 
         with pytest.warns(FutureWarning):
-            self.assertEqual(dummy_b_c_deprecated("A", c="C"), "AbC")
+            dummy_b_c_deprecated("A", b="B")
 
         with pytest.warns(FutureWarning):
-            self.assertEqual(dummy_b_c_deprecated("A", b="B", c="C"), "ABC")
+            dummy_b_c_deprecated("A", c="C")
+
+        with pytest.warns(FutureWarning):
+            dummy_b_c_deprecated("A", b="B", c="C")

--- a/tests/test_utils_deprecation.py
+++ b/tests/test_utils_deprecation.py
@@ -1,4 +1,3 @@
-import re
 import unittest
 import warnings
 

--- a/tests/test_utils_deprecation.py
+++ b/tests/test_utils_deprecation.py
@@ -1,0 +1,82 @@
+import re
+import unittest
+import warnings
+
+import pytest
+
+from huggingface_hub.utils._deprecation import (
+    _deprecate_arguments,
+    _deprecate_positional_args,
+)
+
+
+def dummy(a, b="b", c="c") -> str:
+    return f"{a}{b}{c}"
+
+
+def dummy_kwonly(a, *, b="b", c="c") -> str:
+    return dummy(a, b, c)
+
+
+class TestDeprecationUtils(unittest.TestCase):
+    def test_deprecate_positional_args(self):
+        """Test warnings are triggered when using deprecated positional args.
+
+        Also test that the values are well passed to the decorated function.
+        """
+        dummy_position_deprecated = _deprecate_positional_args(
+            dummy_kwonly, version="xxx"
+        )
+
+        with warnings.catch_warnings():
+            # Assert no warnings when used correctly.
+            # Taken from https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests
+            warnings.simplefilter("error")
+            self.assertEqual(dummy_position_deprecated(a="A", b="B", c="C"), "ABC")
+            self.assertEqual(dummy_position_deprecated("A", b="B", c="C"), "ABC")
+
+        with pytest.warns(FutureWarning):
+            self.assertEqual(dummy_position_deprecated("A", "B", c="C"), "ABC")
+
+        with pytest.warns(FutureWarning):
+            self.assertEqual(dummy_position_deprecated("A", "B", "C"), "ABC")
+
+    def test_deprecate_arguments(self):
+        """Test warnings are triggered when using deprecated arguments.
+
+        Also test that the values are well passed to the decorated function.
+        """
+        dummy_c_deprecated = _deprecate_arguments(
+            dummy, version="xxx", deprecated_args={"c"}
+        )
+        dummy_b_c_deprecated = _deprecate_arguments(
+            dummy, version="xxx", deprecated_args={"b", "c"}
+        )
+
+        with warnings.catch_warnings():
+            # Assert no warnings when used correctly.
+            # Taken from https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests
+            warnings.simplefilter("error")
+            self.assertEqual(dummy_c_deprecated("A"), "Abc")
+            self.assertEqual(dummy_c_deprecated("A", "B"), "ABc")
+            self.assertEqual(dummy_c_deprecated("A", b="B"), "ABc")
+
+            self.assertEqual(dummy_b_c_deprecated("A"), "Abc")
+
+        with pytest.warns(FutureWarning):
+            self.assertEqual(dummy_c_deprecated("A", "B", "C"), "ABC")
+
+        with pytest.warns(FutureWarning):
+            self.assertEqual(dummy_c_deprecated("A", c="C"), "AbC")
+
+        with pytest.warns(FutureWarning):
+            self.assertEqual(dummy_c_deprecated("A", b="B", c="C"), "ABC")
+
+        with pytest.warns(FutureWarning):
+            self.assertEqual(dummy_b_c_deprecated("A", b="B"), "ABc")
+
+        with pytest.warns(FutureWarning):
+            self.assertEqual(dummy_b_c_deprecated("A", c="C"), "AbC")
+
+        with pytest.warns(FutureWarning):
+            self.assertEqual(dummy_b_c_deprecated("A", b="B", c="C"), "ABC")


### PR DESCRIPTION
**Disclaimer:** I made quite some mess with the branch/fork so this PR might be temporary one that we close without merging. I created a branch `wauplin-non-git-mixin` from the `main` of the main repo and merged the branch [non-git-mixin](https://github.com/LysandreJik/huggingface_hub/tree/non-git-mixin) from @LysandreJik's fork. My goal was just to start with a clean state once the merge conflicts were resolved. This PR is quite huge because of the new features from the `main` branch. To see what https://github.com/huggingface/huggingface_hub/pull/847 would be after merging see, see the [diff comparison](https://github.com/huggingface/huggingface_hub/compare/main...huggingface:huggingface_hub:wauplin-non-git-mixin?expand=1) (I would rather not start a new PR from this branch to `main` directly just to avoid losing the previous discussion in https://github.com/huggingface/huggingface_hub/pull/847).

**What is done ?**
- resolve conflicts with `main`
- use `upload_folder` in both hub and keras mixins
- some docstring

**What remains ?**
~- `save pretrained` -> signature changes to return `List[str]` instead of `None`. Does it impact other subclasses and how ? Document it (see [comment](https://github.com/huggingface/huggingface_hub/pull/847#discussion_r862016746)).~-> done
~- adapt tests (and create new ones)~ -> done
~- deprecate previous arguments (`repo_path_or_name`, `repo_url`,  `use_auth_token`, `git_user`, `git_email`)~ -> done
~- deprecate `skip_lfs_files` -> introduced in https://github.com/huggingface/huggingface_hub/pull/858 . For what I understand from [this comment](https://github.com/huggingface/huggingface_hub/pull/858#issuecomment-1112906088), `skip_lfs_files` is now useless since we do not pull the repo anyway => to be deprecated~ -> done

**How to deprecate arguments ?**
I am still wondering what is the policy to deprecate things without breaking changes. 

1. In [this change](https://github.com/huggingface/huggingface_hub/pull/847/files#diff-bf673df3e700e1f9ed9cffa6ce51441acd0474bb67f7ac7728aa336d43216285R217), we force the usage of keyword arguments and add the deprecation decorator at the same time. My understanding would be that in this PR/release (0.9 ?) we add the decorator but we still allow it and in next release (0.10 or 0.11 ?) we add the `*`to force the usage of keyword arguments. Do you confirm ?
2. For argument deprecation, is there a utility decorator I could use same as `_deprecate_positional_args` ? I didn't find any but maybe you already have this in another repo ?
3. In some cases, I don't see how we can avoid breaking changes.
    a. Will work: `use_auth_token`. I feel it's fine because we can take the token from either `token` or `use_auth_token` and both old and new behaviour work.
    b. Will not always work: `repo_path_or_name`. What if the user is passing a path to a local directory on its machine ? We cannot handle it with the new behaviour. Does it mean we still need the old implementation with `Repository` as well and make it live until next release ? I am a bit afraid of "dead code" if we do like this. Any opinion ?
    

I am also fine with merging this PR to Lysandre's repo and then continue the discussion in https://github.com/huggingface/huggingface_hub/pull/847